### PR TITLE
Added term position support.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,18 @@
 
 const VERSION = "1.0.0";
 
+/**
+ * A term position.
+ *
+ * Essentially a struct, this takes a term (word) & a position within a document.
+ */
 class TermPosition {
+  /**
+   * Creates a new term position.
+   * @param {string} term - The term/word to store.
+   * @param {int} position - The position within the document.
+   * @return {this}
+   */
   constructor(term, position) {
     this.term = term;
     this.position = position;
@@ -32,6 +43,13 @@ class BasicPreprocessor {
     this.punctuation = punctuation || /[~`!@#$%^&*\(\)_+=\[\]\{\}\\\|;:'",\.\/<>?-]/g;
   }
 
+  /**
+   * Cleans a word.
+   *
+   * Currently, this is just stripping out basic punctuation characters.
+   * @param {string} word - The word to be cleaned.
+   * @return {string}
+   */
   clean(word) {
     // Dupe it so that we don't modify the original.
     let cleaned = word.slice();
@@ -39,6 +57,19 @@ class BasicPreprocessor {
     return cleaned;
   }
 
+  /**
+   * Potentially appends a new term to the terms list.
+   *
+   * This is largely an _internal_ method.
+   *
+   * This lowercases, then cleans the word. If there are any characters left
+   * post-cleaning, it will create a new `TermPosition`, and append it to
+   * the `terms` list **IN-PLACE**.
+   * @param {array} terms - The existing term list.
+   * @param {string} currentWord - The word to added.
+   * @param {int} wordOffset - The offset of the word within the document.
+   * @return {array}
+   */
   appendTerm(terms, currentWord, wordOffset) {
     // We've encountered the end of the word. Finalize the term.
     const cleaned = this.clean(currentWord.toLowerCase());
@@ -48,6 +79,9 @@ class BasicPreprocessor {
       if (this.skipWords.indexOf(cleaned) < 0) {
         // It's not a skip word. Add it to terms.
         const term = new TermPosition(cleaned, wordOffset);
+        // I don't love that we're modifying the passed array in-place, but
+        // we also don't want O(N) copies of the `terms` per-document.
+        // That's a lot of RAM & allocations on big documents.
         terms.push(term);
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,9 @@ class TermPosition {
  * - splits on whitespace
  */
 class BasicPreprocessor {
-  constructor(splitOn, skipWords, punctuation) {
+  constructor(splitOn, stopWords, punctuation) {
     this.splitOn = splitOn || /\s/;
-    this.skipWords = skipWords || [];
+    this.stopWords = stopWords || [];
     this.punctuation = punctuation || /[~`!@#$%^&*\(\)_+=\[\]\{\}\\\|;:'",\.\/<>?-]/g;
   }
 
@@ -75,9 +75,9 @@ class BasicPreprocessor {
     const cleaned = this.clean(currentWord.toLowerCase());
 
     if (cleaned.length > 0) {
-      // Check the skip word list.
-      if (this.skipWords.indexOf(cleaned) < 0) {
-        // It's not a skip word. Add it to terms.
+      // Check the stop word list.
+      if (this.stopWords.indexOf(cleaned) < 0) {
+        // It's not a stop word. Add it to terms.
         const term = new TermPosition(cleaned, wordOffset);
         // I don't love that we're modifying the passed array in-place, but
         // we also don't want O(N) copies of the `terms` per-document.

--- a/test.html
+++ b/test.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Test MiniSearch</title>
+        <script type="text/javascript">
+            window.addEventListener("load", (ev) => {
+                import('./src/index.js')
+                    .then((module) => {
+                        window.engine = engine = new module.MiniSearch();
+
+                        engine.add("abc", "The dog is a 'hot dog'.");
+                        engine.add("def", "Dogs > Cats");
+                        engine.add("ghi", "the quick brown fox jumps over the lazy dog");
+                        engine.add("jkl", "Am I lazy, or just work smart?");
+
+                        // Then, you can let the user search on the engine...
+                        console.log(engine.search("my dog"));
+                        // ...including limiting results (to just one)...
+                        console.log(engine.search("lazy", 1));
+                        // ...or a second page of ten results!
+                        console.log(engine.search("dogs", 10, 2));
+                    });
+            });
+        </script>
+    </head>
+
+    <body>
+        <h1>Test Mini Search</h1>
+
+        <ol>
+            <li>
+                Run me via `python3 -m http.server 8888`.
+            </li>
+            <li>
+                Open <a href="http://localhost:8888/">http://localhost:8888/</a>
+                in your browser.
+            </li>
+            <li>
+                Open the Javascript console.
+            </li>
+            <li>
+                The engine has a small index built & is available
+                via <code>`window.engine`</code>.
+            </li>
+        </ul>
+    </body>
+</html>

--- a/test/minisearch.test.js
+++ b/test/minisearch.test.js
@@ -1,10 +1,67 @@
 import assert from "assert";
 
 import {
-  BasicEnglishPreprocessor,
+  VERSION,
+  TermPosition,
+  BasicPreprocessor,
   NGramTokenizer,
   MiniSearch,
 } from "../src/index.js";
+
+describe("BasicEnglishPreprocessor", function () {
+  describe("default processing", function () {
+    it("returns the correct terms", function () {
+      const pp = new BasicPreprocessor();
+      const doc = "The dog is hot.";
+
+      const terms = pp.process(doc);
+      assert.equal(terms.length, 4);
+      assert.equal(terms[0].term, "the");
+      assert.equal(terms[0].position, 0);
+      assert.equal(terms[1].term, "dog");
+      assert.equal(terms[1].position, 4);
+      assert.equal(terms[2].term, "is");
+      assert.equal(terms[2].position, 8);
+      assert.equal(terms[3].term, "hot");
+      assert.equal(terms[3].position, 11);
+    });
+
+    it("returns the correct terms with surrounding whitespace", function () {
+      const pp = new BasicPreprocessor();
+      const doc = " The dog is hot.\n ";
+
+      const terms = pp.process(doc);
+      assert.equal(terms.length, 4);
+      assert.equal(terms[0].term, "the");
+      assert.equal(terms[0].position, 1);
+      assert.equal(terms[1].term, "dog");
+      assert.equal(terms[1].position, 5);
+      assert.equal(terms[2].term, "is");
+      assert.equal(terms[2].position, 9);
+      assert.equal(terms[3].term, "hot");
+      assert.equal(terms[3].position, 12);
+    });
+  });
+});
+
+describe("NGramTokenizer", function () {
+  describe("default processing", function () {
+    it("returns the correct n-grams", function () {
+      const ng = new NGramTokenizer();
+      const word = "doggone";
+
+      const tokens = ng.tokenize(word);
+      assert.equal(tokens.length, 5);
+      assert.deepEqual(tokens, [
+        "dog",
+        "ogg",
+        "ggo",
+        "gon",
+        "one",
+      ]);
+    });
+  });
+});
 
 describe("MiniSearch", function () {
   describe("constructor", function () {
@@ -14,6 +71,7 @@ describe("MiniSearch", function () {
       assert.deepEqual(engine.index, {
         "documentIds": {},
         "terms": {},
+        "version": VERSION,
       });
     });
   });

--- a/test/minisearch.test.js
+++ b/test/minisearch.test.js
@@ -42,6 +42,34 @@ describe("BasicEnglishPreprocessor", function () {
       assert.equal(terms[3].position, 12);
     });
   });
+
+  describe("overridden processing", function () {
+    it("correctly handles different splits", function () {
+      const pp = new BasicPreprocessor(/[\n]/);
+      const doc = "The dog\nis hot.\n\n";
+
+      const terms = pp.process(doc);
+      assert.equal(terms.length, 2);
+      assert.equal(terms[0].term, "the dog");
+      assert.equal(terms[0].position, 0);
+      assert.equal(terms[1].term, "is hot");
+      assert.equal(terms[1].position, 8);
+    });
+
+    it("avoids stop words", function () {
+      const pp = new BasicPreprocessor(null, ["the", "a", "an", "is"]);
+      const doc = "The dog is a 'hot dog'.";
+
+      const terms = pp.process(doc);
+      assert.equal(terms.length, 3);
+      assert.equal(terms[0].term, "dog");
+      assert.equal(terms[0].position, 4);
+      assert.equal(terms[1].term, "hot");
+      assert.equal(terms[1].position, 13);
+      assert.equal(terms[2].term, "dog");
+      assert.equal(terms[2].position, 18);
+    });
+  });
 });
 
 describe("NGramTokenizer", function () {
@@ -58,6 +86,24 @@ describe("NGramTokenizer", function () {
         "ggo",
         "gon",
         "one",
+      ]);
+    });
+  });
+
+  describe("overridden processing", function () {
+    it("returns shorter n-grams", function () {
+      const ng = new NGramTokenizer(2);
+      const word = "doggone";
+
+      const tokens = ng.tokenize(word);
+      assert.equal(tokens.length, 6);
+      assert.deepEqual(tokens, [
+        "do",
+        "og",
+        "gg",
+        "go",
+        "on",
+        "ne",
       ]);
     });
   });


### PR DESCRIPTION
Resolves #1, resolves #2, resolves #3 .

**NOT BACKWARD COMPATIBLE!** This should be the last backward-incompatible change before the proper `1.0.0` release.

This paves the way for better scoring, highlighting, etc. In the process of this work, we also gain better Unicode support, as well as index versioning & compatibility checks.

## TODO:

* [x] Added versioning to the index
* [x] Rewrite the preprocessor `process` code, iterating over the document body & generating a list instead of effectively just `.toLowerCase().replace().split()`
* [x] Change the preprocessor `process` api to emit a list of `[[word, position], [word, position], ...]` values
* [ ] ~Change the tokenizer `tokenize` api to include the position as well~ Unneeded
* [x] Change the index to store lists of positions instead of just the count
* [x] Change scoring to check the length of the lists instead of just the count