### PR TITLE
Renamed the package to `nanosearch`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# `minisearch`
+# `nanosearch`
 
 A tiny search engine.
 
-Suitable for in-browser use, this provides n-gram based, English search results.
+Suitable for in-browser use, this provides n-gram based search results.
 
 
 ## Quickstart
 
 ```js
-import { MiniSearch } from '@toastdriven/minisearch';
+import { SearchEngine } from '@toastdriven/nanosearch';
 
 // Create a search engine.
-const engine = new MiniSearch();
+const engine = new SearchEngine();
 
 // Index some documents.
 // First parameter is the unique document ID, second is the document text.
@@ -31,7 +31,7 @@ engine.search("dogs", 10, 2);
 
 ## Installation
 
-`$ npm install @toastdriven/minisearch`
+`$ npm install @toastdriven/nanosearch`
 
 
 ## Requirements
@@ -42,8 +42,8 @@ engine.search("dogs", 10, 2);
 ## Tests
 
 ```shell
-$ git clone git@github.com:toastdriven/minisearch.git
-$ cd minisearch
+$ git clone git@github.com:toastdriven/nanosearch.git
+$ cd nanosearch
 $ npm install
 $ npm test
 ```
@@ -52,8 +52,8 @@ $ npm test
 ## Docs
 
 ```shell
-$ git clone git@github.com:toastdriven/minisearch.git
-$ cd minisearch
+$ git clone git@github.com:toastdriven/nanosearch.git
+$ cd nanosearch
 $ npm install
 $ ./node_modules/.bin/jsdoc -r -d ~/Desktop/out --package package.json --readme README.md src
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "minisearch",
+  "name": "nanosearch",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "minisearch",
+      "name": "nanosearch",
       "version": "1.0.0",
       "license": "BSD-3-Clause",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "minisearch",
+  "name": "nanosearch",
   "version": "1.0.0",
   "description": "A tiny search engine.",
   "main": "src/index.js",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/toastdriven/minisearch.git"
+    "url": "git+https://github.com/toastdriven/nanosearch.git"
   },
   "keywords": [
     "search",
@@ -22,9 +22,9 @@
   "author": "Daniel Lindsley <daniel@toastdriven.com>",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/toastdriven/evstate/issues"
+    "url": "https://github.com/toastdriven/nanosearch/issues"
   },
-  "homepage": "https://github.com/toastdriven/evstate#readme",
+  "homepage": "https://github.com/toastdriven/nanosearch#readme",
   "devDependencies": {
     "jsdoc": "^3.6.11",
     "mocha": "^9.1.3"

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 /**
- * minisearch: A tiny search engine.
+ * nanosearch: A tiny search engine.
  *
  * Default implementation is based off of n-grams (default size: `3`).
  *
- * @module minisearch
+ * @module nanosearch
  */
 
 const VERSION = "1.0.0";
@@ -191,11 +191,11 @@ class NGramTokenizer {
 }
 
 /**
- * A mini search engine.
+ * A tiny search engine.
  *
  * Usage:
  *
- *   const engine = new MiniSearch();
+ *   const engine = new SearchEngine();
  *
  *   // Add some documents. Call for each document you need to index.
  *   engine.add(uniqueDocumentId, documentText);
@@ -203,7 +203,7 @@ class NGramTokenizer {
  *   // Later, you can let the user search & return the first 10 results.
  *   const results = engine.search(userQuery, 10);
  */
-class MiniSearch {
+class SearchEngine {
   /**
    * Creates a new search engine.
    * @param {object} existingIndex - The existing index or `undefined` (fresh
@@ -442,5 +442,5 @@ export {
   TermPosition,
   BasicPreprocessor,
   NGramTokenizer,
-  MiniSearch,
+  SearchEngine,
 };

--- a/test.html
+++ b/test.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Test MiniSearch</title>
+        <title>Test NanoSearch</title>
         <script type="text/javascript">
             window.addEventListener("load", (ev) => {
                 import('./src/index.js')
                     .then((module) => {
-                        window.engine = engine = new module.MiniSearch();
+                        window.engine = engine = new module.SearchEngine();
 
                         engine.add("abc", "The dog is a 'hot dog'.");
                         engine.add("def", "Dogs > Cats");
@@ -25,7 +25,7 @@
     </head>
 
     <body>
-        <h1>Test Mini Search</h1>
+        <h1>Test NanoSearch</h1>
 
         <ol>
             <li>
@@ -39,7 +39,7 @@
                 Open the Javascript console.
             </li>
             <li>
-                The engine has a small index built & is available
+                The search engine has a small index built & is available
                 via <code>`window.engine`</code>.
             </li>
         </ul>

--- a/test/nanosearch.test.js
+++ b/test/nanosearch.test.js
@@ -5,7 +5,7 @@ import {
   TermPosition,
   BasicPreprocessor,
   NGramTokenizer,
-  MiniSearch,
+  SearchEngine,
 } from "../src/index.js";
 
 describe("BasicEnglishPreprocessor", function () {
@@ -164,10 +164,10 @@ describe("NGramTokenizer", function () {
   });
 });
 
-describe("MiniSearch", function () {
+describe("SearchEngine", function () {
   describe("constructor", function () {
     it("sets internal state", function () {
-      const engine = new MiniSearch();
+      const engine = new SearchEngine();
 
       assert.deepEqual(engine.index, {
         "documentIds": {},
@@ -179,7 +179,7 @@ describe("MiniSearch", function () {
 
   describe("add", function () {
     it("correctly adds a document", function () {
-      const engine = new MiniSearch();
+      const engine = new SearchEngine();
 
       engine.add("abc", "The dogs are loose");
 
@@ -190,7 +190,7 @@ describe("MiniSearch", function () {
 
   describe("clear", function () {
     it("correctly empties the index", function () {
-      const engine = new MiniSearch();
+      const engine = new SearchEngine();
 
       engine.add("abc", "The dogs are loose");
       engine.add("def", "No cats aren't");
@@ -207,7 +207,7 @@ describe("MiniSearch", function () {
 
   describe("remove", function () {
     it("correctly removes a document", function () {
-      const engine = new MiniSearch();
+      const engine = new SearchEngine();
 
       engine.add("abc", "The dogs are loose");
       engine.add("def", "No cats aren't");
@@ -224,7 +224,7 @@ describe("MiniSearch", function () {
 
   describe("search", function () {
     it("searches against the index", function () {
-      const engine = new MiniSearch();
+      const engine = new SearchEngine();
 
       engine.add("abc", "The dog is a 'hot dog'.");
       engine.add("def", "Dogs > Cats");
@@ -242,7 +242,7 @@ describe("MiniSearch", function () {
 
   describe("toJson", function () {
     it("stores to JSON", function () {
-      const engine = new MiniSearch();
+      const engine = new SearchEngine();
 
       engine.add("abc", "The dog is a 'hot dog'.");
       engine.add("def", "Dogs > Cats");
@@ -259,7 +259,7 @@ describe("MiniSearch", function () {
 
   describe("fromJson", function () {
     it("loads from JSON", function () {
-      const engine = new MiniSearch();
+      const engine = new SearchEngine();
 
       // Sanity check.
       assert.equal(Object.keys(engine.index["documentIds"]).length, 0);


### PR DESCRIPTION
Resolves #8.

Previously, this package was known as `minisearch`. However, there's already a long-standing package on NPM with the same name. And we're currently smaller than 500 lines (w/ docs!), so `nanosearch` it is.