### PR TITLE
Changed searching to return a Results object instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,25 @@ engine.add("ghi", "the quick brown fox jumps over the lazy dog");
 engine.add("jkl", "Am I lazy, or just work smart?");
 
 // Then, you can let the user search on the engine...
-engine.search("my dog");
+let myDogResults = engine.search("my dog");
+myDogResults.count(); // 3
+
+for(let res of myDogResults.iterator()) {
+  console.log(res.docId); // ex: "def"
+  console.log(res.score); // ex: 0.2727272727272727
+}
+
 // ...including limiting results (to just one)...
-engine.search("lazy", 1);
-// ...or a second page of ten results!
-engine.search("dogs", 10, 2);
+let lazyResults = engine.search("lazy");
+let topResult = lazyResults.at(0);
+console.log(topResult);
+
+// ...or making pages of ten results!
+let dogResults = engine.search("dogs");
+let pageOne = dogResults.slice(0, 10);
+let pageTwo = dogResults.slice(10, 20);
+console.log(pageOne);
+console.log(pageTwo);
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,74 @@ class TermPosition {
   }
 }
 
+function* _resultsIterator(results, start = 0, end = Infinity, step = 1) {
+  let iterationCount = 0;
+  let actualEnd = Math.min(results.length, end);
+
+  for (let i = start; i < actualEnd; i += step) {
+    iterationCount++;
+    yield results.at(i);
+  }
+
+  return iterationCount;
+}
+
+/**
+ * A result set.
+ *
+ * An object that makes working with all the results from a query easier.
+ */
+class Results {
+  /**
+   * Creates a new result.
+   * @param {string} query - The query searched on.
+   * @param {array} results - The results found from searching.
+   * @return {this}
+   */
+  constructor(query, results) {
+    this.query = query;
+    this._allResults = results || [];
+  }
+
+  /**
+   * Creates an iterator that allows you to loop over results.
+   * @param {int} start - The starting offset. Default is `0`.
+   * @param {int} end - The ending offset. Default is `Infinity`.
+   * @param {int} step - The step value. Default is `1`.
+   * @return {generator}
+   */
+  iterator(start = 0, end = Infinity, step = 1) {
+    return _resultsIterator(this._allResults, start, end, step);
+  }
+
+  /**
+   * Returns a result at a specific offset.
+   * @param {int} offset - The position within the results.
+   * @return {this}
+   */
+  at(offset) {
+    return this._allResults.at(offset);
+  }
+
+  /**
+   * Returns the total count of matches.
+   * @return {int}
+   */
+  count() {
+    return this._allResults.length;
+  }
+
+  /**
+   * Slices the result set.
+   * @param {int} start - The starting offset.
+   * @param {int} end - The ending offset (exclusive).
+   * @return {array}
+   */
+  slice(start, end) {
+    return this._allResults.slice(start, end);
+  }
+}
+
 /**
  * A basic preprocessor.
  *
@@ -376,14 +444,9 @@ class SearchEngine {
   /**
    * Performs a search against the index & returns results.
    * @param {string} query - The user's query to search on.
-   * @param {int} limit - The number of results to return.
-   * @param {int} start - The starting offset of the results.
-   * @return {array}
+   * @return {Results}
    */
-  search(query, limit, start) {
-    limit = parseInt(limit) || 10;
-    start = parseInt(start) || 0;
-
+  search(query) {
     const allResults = this._search(query);
 
     // Reorder all the results by score.
@@ -397,7 +460,7 @@ class SearchEngine {
       return 0;
     });
 
-    return allResults.slice(start, start + limit);
+    return new Results(query, allResults);
   }
 
   /**

--- a/test.html
+++ b/test.html
@@ -14,11 +14,25 @@
                         engine.add("jkl", "Am I lazy, or just work smart?");
 
                         // Then, you can let the user search on the engine...
-                        console.log(engine.search("my dog"));
+                        let myDogResults = engine.search("my dog");
+                        myDogResults.count(); // 3
+
+                        for (let res of myDogResults.iterator()) {
+                            console.log(res.docId); // ex: "def"
+                            console.log(res.score); // ex: 0.2727272727272727
+                        }
+
                         // ...including limiting results (to just one)...
-                        console.log(engine.search("lazy", 1));
-                        // ...or a second page of ten results!
-                        console.log(engine.search("dogs", 10, 2));
+                        let lazyResults = engine.search("lazy");
+                        let topResult = lazyResults.at(0);
+                        console.log(topResult);
+
+                        // ...or making pages of ten results!
+                        let dogResults = engine.search("dogs");
+                        let pageOne = dogResults.slice(0, 10);
+                        let pageTwo = dogResults.slice(10, 20);
+                        console.log(pageOne);
+                        console.log(pageTwo);
                     });
             });
         </script>

--- a/test/nanosearch.test.js
+++ b/test/nanosearch.test.js
@@ -231,12 +231,43 @@ describe("SearchEngine", function () {
       engine.add("ghi", "the quick brown fox jumps over the lazy dog");
       engine.add("jkl", "Am I lazy, or just work smart?");
 
-      const results = engine.search("my dog");
+      let results = engine.search("my dog");
+      assert.equal(results.count(), 3);
 
-      assert.equal(results.length, 3);
-      assert.equal(results[0]["docId"], "def");
-      assert.equal(results[1]["docId"], "abc");
-      assert.equal(results[2]["docId"], "ghi");
+      let iter = results.iterator();
+      let res = iter.next();
+      assert.equal(res.value.docId, "def");
+      assert.equal((res.value.score > 0) && (res.value.score < 1), true);
+      assert.equal(res.done, false);
+
+      res = iter.next();
+      assert.equal(res.value.docId, "abc");
+      assert.equal((res.value.score > 0) && (res.value.score < 1), true);
+      assert.equal(res.done, false);
+
+      res = iter.next();
+      assert.equal(res.value.docId, "ghi");
+      assert.equal((res.value.score > 0) && (res.value.score < 1), true);
+      assert.equal(res.done, false);
+
+      res = iter.next();
+      assert.equal(res.done, true);
+
+      results = engine.search("lazy");
+      let topResult = results.at(0);
+      assert.equal(topResult.docId, "jkl");
+
+      results = engine.search("dogs");
+      let pageOne = results.slice(0, 10);
+      let pageTwo = results.slice(10, 20);
+
+      assert.equal(pageOne.length, 3);
+      assert.equal(pageOne[0].docId, "def");
+      assert.equal(pageOne[1].docId, "abc");
+      assert.equal(pageOne[2].docId, "ghi");
+
+      // There is no page two.
+      assert.equal(pageTwo.length, 0);
     });
   });
 
@@ -283,7 +314,7 @@ describe("SearchEngine", function () {
 
       // Sanity check.
       const results = engine.search("dog");
-      assert.equal(results.length, 1);
+      assert.equal(results.count(), 1);
     });
   });
 });


### PR DESCRIPTION
A fundamental problem with the existing API when searching is that you don't get a total result count back. This is fine for auto-complete-style applications (where you're rarely going to be showing more than a handful of results), but makes providing paginated results more difficult.

This changes the `SearchEngine.search` API slightly, to drop the previous `start` & `limit` arguments, as well as returning a `Results` object instead of just a sliced array.

The new `Results` object provides an iterator, the total results count, specific offset access, and slicing (where the dropped `start` & `limit` can be re-applied) as it's API. This makes dealing with larger result sets more palatable, and offers the ability to provide the user better information.

Unfortunately, it's backward-incompatible. Sucks to have to do a major revision bump so soon, & poor planning on my part.